### PR TITLE
Implement block formatting and other fixes

### DIFF
--- a/yoga/Utils.h
+++ b/yoga/Utils.h
@@ -38,6 +38,7 @@
 
 struct YGCollectFlexItemsRowValues {
   uint32_t itemsOnLine;
+  bool isBlockNonInline;
   float sizeConsumedOnCurrentLine;
   float totalFlexGrowFactors;
   float totalFlexShrinkScaledFactors;

--- a/yoga/YGConfig.h
+++ b/yoga/YGConfig.h
@@ -36,6 +36,7 @@ private:
   bool loggerUsesContext_;
 
 public:
+  bool enableBlockFormatting = false;
   bool useWebDefaults = false;
   bool useLegacyStretchBehaviour = false;
   bool shouldDiffLayoutWithoutLegacyStretchBehaviour = false;

--- a/yoga/YGEnums.cpp
+++ b/yoga/YGEnums.cpp
@@ -7,6 +7,18 @@
 
 #include "YGEnums.h"
 
+const char* YGAlignTextToString(const YGAlignText value) {
+  switch (value) {
+    case YGAlignTextLeft:
+      return "left";
+    case YGAlignTextRight:
+      return "right";
+    case YGAlignTextCenter:
+      return "center";
+  }
+  return "unknown";
+}
+
 const char* YGAlignToString(const YGAlign value) {
   switch (value) {
     case YGAlignAuto:

--- a/yoga/YGEnums.cpp
+++ b/yoga/YGEnums.cpp
@@ -55,6 +55,8 @@ const char* YGDisplayToString(const YGDisplay value) {
   switch (value) {
     case YGDisplayFlex:
       return "flex";
+    case YGDisplayBlock:
+      return "block";
     case YGDisplayNone:
       return "none";
   }

--- a/yoga/YGEnums.cpp
+++ b/yoga/YGEnums.cpp
@@ -199,6 +199,8 @@ const char* YGPositionTypeToString(const YGPositionType value) {
       return "relative";
     case YGPositionTypeAbsolute:
       return "absolute";
+    case YGPositionTypeFixed:
+      return "fixed";
   }
   return "unknown";
 }

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -73,7 +73,7 @@ YG_ENUM_SEQ_DECL(
     YGDirectionLTR,
     YGDirectionRTL)
 
-YG_ENUM_SEQ_DECL(YGDisplay, YGDisplayFlex, YGDisplayNone)
+YG_ENUM_SEQ_DECL(YGDisplay, YGDisplayFlex, YGDisplayBlock, YGDisplayNone)
 
 YG_ENUM_SEQ_DECL(
     YGEdge,

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -65,6 +65,12 @@ YG_ENUM_SEQ_DECL(
     YGAlignSpaceBetween,
     YGAlignSpaceAround);
 
+YG_ENUM_SEQ_DECL(
+    YGAlignText,
+    YGAlignTextLeft,
+    YGAlignTextRight,
+    YGAlignTextCenter);
+
 YG_ENUM_SEQ_DECL(YGDimension, YGDimensionWidth, YGDimensionHeight)
 
 YG_ENUM_SEQ_DECL(

--- a/yoga/YGEnums.h
+++ b/yoga/YGEnums.h
@@ -138,7 +138,8 @@ YG_ENUM_SEQ_DECL(
     YGPositionType,
     YGPositionTypeStatic,
     YGPositionTypeRelative,
-    YGPositionTypeAbsolute)
+    YGPositionTypeAbsolute,
+    YGPositionTypeFixed)
 
 YG_ENUM_DECL(
     YGPrintOptions,

--- a/yoga/YGLayout.cpp
+++ b/yoga/YGLayout.cpp
@@ -12,6 +12,7 @@ using namespace facebook;
 
 bool YGLayout::operator==(YGLayout layout) const {
   bool isEqual = YGFloatArrayEqual(position, layout.position) &&
+      YGFloatArrayEqual(positionBeforeOffset, layout.positionBeforeOffset) &&
       YGFloatArrayEqual(dimensions, layout.dimensions) &&
       YGFloatArrayEqual(margin, layout.margin) &&
       YGFloatArrayEqual(border, layout.border) &&

--- a/yoga/YGLayout.h
+++ b/yoga/YGLayout.h
@@ -14,6 +14,7 @@ using namespace facebook::yoga;
 
 struct YGLayout {
   std::array<float, 4> position = {};
+  std::array<float, 4> positionBeforeOffset = {};
   std::array<float, 2> dimensions = {{YGUndefined, YGUndefined}};
   std::array<float, 4> margin = {};
   std::array<float, 4> border = {};

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -462,6 +462,17 @@ float YGNode::resolveFlexShrink() const {
       : kDefaultFlexShrink;
 }
 
+bool YGNode::isDisplayBlock() const {
+  return style_.display() == YGDisplayBlock;
+}
+
+bool YGNode::isDisplayInline() const {
+  if (style_.displayInline().isUndefined()) {
+    return false;
+  }
+  return style_.displayInline().unwrap() > 0.5f;
+}
+
 bool YGNode::isNodeFlexible() {
   return (
       (style_.positionType() != YGPositionTypeAbsolute) &&

--- a/yoga/YGNode.cpp
+++ b/yoga/YGNode.cpp
@@ -462,6 +462,11 @@ float YGNode::resolveFlexShrink() const {
       : kDefaultFlexShrink;
 }
 
+bool YGNode::isPositionTypeExcluded() const {
+  return style_.positionType() == YGPositionTypeAbsolute ||
+         style_.positionType() == YGPositionTypeFixed;
+}
+
 bool YGNode::isDisplayBlock() const {
   return style_.display() == YGDisplayBlock;
 }
@@ -475,7 +480,7 @@ bool YGNode::isDisplayInline() const {
 
 bool YGNode::isNodeFlexible() {
   return (
-      (style_.positionType() != YGPositionTypeAbsolute) &&
+      (!isPositionTypeExcluded()) &&
       (resolveFlexGrow() != 0 || resolveFlexShrink() != 0));
 }
 

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -344,6 +344,7 @@ public:
   void markDirtyAndPropogate();
   float resolveFlexGrow() const;
   float resolveFlexShrink() const;
+  bool isPositionTypeExcluded() const;
   bool isDisplayBlock() const;
   bool isDisplayInline() const;
   bool isNodeFlexible();

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -339,6 +339,8 @@ public:
   void markDirtyAndPropogate();
   float resolveFlexGrow() const;
   float resolveFlexShrink() const;
+  bool isDisplayBlock() const;
+  bool isDisplayInline() const;
   bool isNodeFlexible();
   bool didUseLegacyFlag();
   bool isLayoutTreeEqualToNode(const YGNode& node) const;

--- a/yoga/YGNode.h
+++ b/yoga/YGNode.h
@@ -58,6 +58,7 @@ private:
   uint32_t lineIndex_ = 0;
   YGNodeRef owner_ = nullptr;
   YGVector children_ = {};
+  YGVector relativeAbsChildren_ = {};
   YGConfigRef config_;
   std::array<YGValue, 2> resolvedDimensions_ = {
       {YGValueUndefined, YGValueUndefined}};
@@ -160,6 +161,8 @@ public:
   YGNodeRef getParent() const { return getOwner(); }
 
   const YGVector& getChildren() const { return children_; }
+  
+  const YGVector& getRelativeAbsChildren() const { return relativeAbsChildren_; }
 
   // Applies a callback to all children, after cloning them if they are not
   // owned.
@@ -293,6 +296,8 @@ public:
   void setOwner(YGNodeRef owner) { owner_ = owner; }
 
   void setChildren(const YGVector& children) { children_ = children; }
+  
+  void addRelativeAbsChild(YGNodeRef child) { relativeAbsChildren_.push_back(child); }
 
   // TODO: rvalue override for setChildren
 

--- a/yoga/YGNodePrint.cpp
+++ b/yoga/YGNodePrint.cpp
@@ -153,6 +153,10 @@ void YGNodeToString(
       appendFormatedString(
           str, "align-items: %s; ", YGAlignToString(style.alignItems()));
     }
+    if (style.textAlign() != YGNode().getStyle().textAlign()) {
+      appendFormatedString(
+          str, "text-align: %s; ", YGAlignTextToString(style.textAlign()));
+    }
     if (style.alignContent() != YGNode().getStyle().alignContent()) {
       appendFormatedString(
           str, "align-content: %s; ", YGAlignToString(style.alignContent()));

--- a/yoga/YGNodePrint.cpp
+++ b/yoga/YGNodePrint.cpp
@@ -176,8 +176,13 @@ void YGNodeToString(
           str, "overflow: %s; ", YGOverflowToString(style.overflow()));
     }
 
-    if (style.display() != YGNode().getStyle().display()) {
-      appendFormatedString(
+    if (style.display() != YGNode().getStyle().display()
+        || style.displayInline() != YGNode().getStyle().displayInline()) {
+      if (style.displayInline())
+        appendFormatedString(
+          str, "display: inline-%s; ", YGDisplayToString(style.display()));
+      else
+        appendFormatedString(
           str, "display: %s; ", YGDisplayToString(style.display()));
     }
     appendEdges(str, "margin", style.margin());

--- a/yoga/YGNodePrint.cpp
+++ b/yoga/YGNodePrint.cpp
@@ -178,7 +178,7 @@ void YGNodeToString(
 
     if (style.display() != YGNode().getStyle().display()
         || style.displayInline() != YGNode().getStyle().displayInline()) {
-      if (style.displayInline())
+      if (style.displayInline().unwrap() > 0.5f) //TODO: convert to bool properly
         appendFormatedString(
           str, "display: inline-%s; ", YGDisplayToString(style.display()));
       else

--- a/yoga/YGStyle.cpp
+++ b/yoga/YGStyle.cpp
@@ -13,6 +13,7 @@ bool operator==(const YGStyle& lhs, const YGStyle& rhs) {
   bool areNonFloatValuesEqual = lhs.direction() == rhs.direction() &&
       lhs.flexDirection() == rhs.flexDirection() &&
       lhs.justifyContent() == rhs.justifyContent() &&
+      lhs.textAlign() == rhs.textAlign() &&
       lhs.alignContent() == rhs.alignContent() &&
       lhs.alignItems() == rhs.alignItems() &&
       lhs.alignSelf() == rhs.alignSelf() &&

--- a/yoga/YGStyle.cpp
+++ b/yoga/YGStyle.cpp
@@ -51,6 +51,13 @@ bool operator==(const YGStyle& lhs, const YGStyle& rhs) {
     areNonFloatValuesEqual =
         areNonFloatValuesEqual && lhs.aspectRatio() == rhs.aspectRatio();
   }
+  
+  areNonFloatValuesEqual = areNonFloatValuesEqual &&
+      lhs.displayInline().isUndefined() == rhs.displayInline().isUndefined();
+  if (areNonFloatValuesEqual && !rhs.displayInline().isUndefined()) {
+    areNonFloatValuesEqual =
+        areNonFloatValuesEqual && lhs.displayInline() == rhs.displayInline();
+  }
 
   return areNonFloatValuesEqual;
 }

--- a/yoga/YGStyle.h
+++ b/yoga/YGStyle.h
@@ -78,6 +78,7 @@ public:
 
   YGStyle() {
     display() = YGDisplayBlock;
+    textAlign() = YGAlignTextLeft;
     alignContent() = YGAlignFlexStart;
     alignItems() = YGAlignStretch;
   }
@@ -89,8 +90,10 @@ private:
       directionOffset + facebook::yoga::detail::bitWidthFn<YGDirection>();
   static constexpr size_t justifyContentOffset = flexdirectionOffset +
       facebook::yoga::detail::bitWidthFn<YGFlexDirection>();
+  static constexpr size_t textAlignOffset =
+      justifyContentOffset + facebook::yoga::detail::bitWidthFn<YGAlignText>();
   static constexpr size_t alignContentOffset =
-      justifyContentOffset + facebook::yoga::detail::bitWidthFn<YGJustify>();
+      textAlignOffset + facebook::yoga::detail::bitWidthFn<YGJustify>();
   static constexpr size_t alignItemsOffset =
       alignContentOffset + facebook::yoga::detail::bitWidthFn<YGAlign>();
   static constexpr size_t alignSelfOffset =
@@ -146,7 +149,13 @@ public:
   BitfieldRef<YGJustify> justifyContent() {
     return {*this, justifyContentOffset};
   }
-
+  
+  YGAlignText textAlign() const {
+    return facebook::yoga::detail::getEnumData<YGAlignText>(
+        flags, textAlignOffset);
+  }
+  BitfieldRef<YGAlignText> textAlign() { return {*this, textAlignOffset}; }
+  
   YGAlign alignContent() const {
     return facebook::yoga::detail::getEnumData<YGAlign>(
         flags, alignContentOffset);

--- a/yoga/YGStyle.h
+++ b/yoga/YGStyle.h
@@ -108,6 +108,7 @@ private:
   YGFloatOptional flex_ = {};
   YGFloatOptional flexGrow_ = {};
   YGFloatOptional flexShrink_ = {};
+  YGFloatOptional displayInline_ = YGFloatOptional(0.f);
   CompactValue flexBasis_ = CompactValue::ofAuto();
   Edges margin_ = {};
   Edges position_ = {};
@@ -185,6 +186,9 @@ public:
     return facebook::yoga::detail::getEnumData<YGDisplay>(flags, displayOffset);
   }
   BitfieldRef<YGDisplay> display() { return {*this, displayOffset}; }
+  
+  YGFloatOptional displayInline() const { return displayInline_; }
+  Ref<YGFloatOptional, &YGStyle::displayInline_> displayInline() { return {*this}; }
 
   YGFloatOptional flex() const { return flex_; }
   Ref<YGFloatOptional, &YGStyle::flex_> flex() { return {*this}; }

--- a/yoga/YGStyle.h
+++ b/yoga/YGStyle.h
@@ -77,6 +77,7 @@ public:
   };
 
   YGStyle() {
+    display() = YGDisplayBlock;
     alignContent() = YGAlignFlexStart;
     alignItems() = YGAlignStretch;
   }

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -588,6 +588,16 @@ YOGA_EXPORT YGJustify YGNodeStyleGetJustifyContent(const YGNodeConstRef node) {
   return node->getStyle().justifyContent();
 }
 
+YOGA_EXPORT void YGNodeStyleSetTextAlign(
+    const YGNodeRef node,
+    const YGAlignText textAlign) {
+  updateStyle<MSVC_HINT(textAlign)>(
+      node, &YGStyle::textAlign, textAlign);
+}
+YOGA_EXPORT YGAlignText YGNodeStyleGetTextAlign(const YGNodeConstRef node) {
+  return node->getStyle().textAlign();
+}
+
 YOGA_EXPORT void YGNodeStyleSetAlignContent(
     const YGNodeRef node,
     const YGAlign alignContent) {
@@ -2632,7 +2642,23 @@ static void YGJustifyMainAxis(
   // each two elements.
   float leadingMainDim = 0;
   float betweenMainDim = 0;
-  const YGJustify justifyContent = node->getStyle().justifyContent();
+  YGJustify justifyContent = node->getStyle().justifyContent();
+  
+  // In block formatting, text-align should define the same behaviour as justify-content at this point
+  if (node->isDisplayBlock())
+  {
+    switch (node->getStyle().textAlign()) {
+      case YGAlignTextLeft:
+        justifyContent = YGJustifyFlexStart;
+        break;
+      case YGAlignTextRight:
+        justifyContent = YGJustifyFlexEnd;
+        break;
+      case YGAlignTextCenter:
+        justifyContent = YGJustifyCenter;
+        break;
+    }
+  }
 
   if (numberOfAutoMarginsOnCurrentLine == 0) {
     switch (justifyContent) {

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -4084,14 +4084,6 @@ static void YGNodeBlockImpl(
           -collectedFlexItemsValues.sizeConsumedOnCurrentLine;
     }
     
-    if (collectedFlexItemsValues.isBlockNonInline)
-    {
-      if (collectedFlexItemsValues.sizeConsumedOnCurrentLine > 0)
-      {
-        printf("widthMode: %s heightMode: %s\n", YGMeasureModeToString(widthMeasureMode), YGMeasureModeToString(heightMeasureMode));
-        printf("mainMode: %s crossMode: %s\n", YGMeasureModeToString(measureModeMainDim), YGMeasureModeToString(measureModeCrossDim));
-      }
-    }
     if (!canSkipFlex) {
       YGResolveFlexibleLength(
           node,

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -1311,19 +1311,19 @@ static void YGNodeComputeFlexBasisForChild(
     const YGFloatOptional paddingAndBorder = YGFloatOptional(
         YGNodePaddingAndBorderForAxis(child, YGFlexDirectionRow, ownerWidth));
 
-    child->setLayoutComputedFlexBasis(YGFloatOptionalMax(
+    child->setLayoutComputedFlexBasis(
         YGResolveValue(
-            child->getResolvedDimensions()[YGDimensionWidth], ownerWidth),
-        paddingAndBorder));
+            child->getResolvedDimensions()[YGDimensionWidth], ownerWidth) +
+        paddingAndBorder);
   } else if (!isMainAxisRow && isColumnStyleDimDefined) {
     // The height is definite, so use that as the flex basis.
     const YGFloatOptional paddingAndBorder =
         YGFloatOptional(YGNodePaddingAndBorderForAxis(
             child, YGFlexDirectionColumn, ownerWidth));
-    child->setLayoutComputedFlexBasis(YGFloatOptionalMax(
+    child->setLayoutComputedFlexBasis(
         YGResolveValue(
-            child->getResolvedDimensions()[YGDimensionHeight], ownerHeight),
-        paddingAndBorder));
+            child->getResolvedDimensions()[YGDimensionHeight], ownerHeight) +
+        paddingAndBorder);
   }
   // Otherwise, we need to keep looking...
   else {

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -1097,7 +1097,7 @@ static float YGBaseline(const YGNodeRef node, void* layoutContext) {
     if (child->getLineIndex() > 0) {
       break;
     }
-    if (child->getStyle().positionType() == YGPositionTypeAbsolute) {
+    if (child->isPositionTypeExcluded()) {
       continue;
     }
     if (YGNodeAlignItem(node, child) == YGAlignBaseline ||
@@ -1129,7 +1129,7 @@ static bool YGIsBaselineLayout(const YGNodeRef node) {
   const uint32_t childCount = YGNodeGetChildCount(node);
   for (uint32_t i = 0; i < childCount; i++) {
     const YGNodeRef child = YGNodeGetChild(node, i);
-    if (child->getStyle().positionType() != YGPositionTypeAbsolute &&
+    if (!child->isPositionTypeExcluded() &&
         child->getStyle().alignSelf() == YGAlignBaseline) {
       return true;
     }
@@ -2031,7 +2031,7 @@ static float YGNodeComputeFlexBasisForChildren(
           childDirection, mainDim, crossDim, availableInnerWidth);
     }
 
-    if (child->getStyle().positionType() == YGPositionTypeAbsolute) {
+    if (child->isPositionTypeExcluded()) {
       continue;
     }
     if (child == singleFlexChild) {
@@ -2093,7 +2093,7 @@ static YGCollectFlexItemsRowValues YGCalculateCollectFlexItemsRowValues(
   for (; endOfLineIndex < node->getChildren().size(); endOfLineIndex++) {
     const YGNodeRef child = node->getChild(endOfLineIndex);
     if (child->getStyle().display() == YGDisplayNone ||
-        child->getStyle().positionType() == YGPositionTypeAbsolute) {
+        child->isPositionTypeExcluded()) {
       continue;
     }
     child->setLineIndex(lineCount);
@@ -2186,7 +2186,7 @@ static YGCollectFlexItemsRowValues YGCalculateCollectBlockItemsRowValues(
     // Fetch next child and check if it should be added
     const YGNodeRef child = node->getChild(endOfLineIndex);
     if (child->getStyle().display() == YGDisplayNone ||
-        child->getStyle().positionType() == YGPositionTypeAbsolute) {
+        child->isPositionTypeExcluded()) {
       continue;
     }
     
@@ -2696,7 +2696,7 @@ static void YGJustifyMainAxis(
        i < collectedFlexItemsValues.endOfLineIndex;
        i++) {
     const YGNodeRef child = node->getChild(i);
-    if (child->getStyle().positionType() != YGPositionTypeAbsolute) {
+    if (!child->isPositionTypeExcluded()) {
       if (child->marginLeadingValue(mainAxis).unit == YGUnitAuto) {
         numberOfAutoMarginsOnCurrentLine++;
       }
@@ -2779,7 +2779,8 @@ static void YGJustifyMainAxis(
     if (childStyle.display() == YGDisplayNone) {
       continue;
     }
-    if (childStyle.positionType() == YGPositionTypeAbsolute &&
+    if ((childStyle.positionType() == YGPositionTypeAbsolute ||
+        childStyle.positionType() == YGPositionTypeAbsolute) &&
         child->isLeadingPositionDefined(mainAxis)) {
       if (performLayout) {
         // In case the child is position absolute and has left/top being
@@ -2796,7 +2797,8 @@ static void YGJustifyMainAxis(
       // Now that we placed the element, we need to update the variables.
       // We need to do that only for relative elements. Absolute elements do not
       // take part in that phase.
-      if (childStyle.positionType() != YGPositionTypeAbsolute) {
+      if (childStyle.positionType() != YGPositionTypeAbsolute &&
+          childStyle.positionType() != YGPositionTypeFixed) {
         if (child->marginLeadingValue(mainAxis).unit == YGUnitAuto) {
           collectedFlexItemsValues.mainDim +=
               collectedFlexItemsValues.remainingFreeSpace /
@@ -3342,7 +3344,7 @@ static void YGNodelayoutImpl(
         if (child->getStyle().display() == YGDisplayNone) {
           continue;
         }
-        if (child->getStyle().positionType() == YGPositionTypeAbsolute) {
+        if (child->isPositionTypeExcluded()) {
           // If the child is absolutely positioned and has a
           // top/left/bottom/right set, override all the previously computed
           // positions to set it correctly.
@@ -3543,7 +3545,7 @@ static void YGNodelayoutImpl(
         if (child->getStyle().display() == YGDisplayNone) {
           continue;
         }
-        if (child->getStyle().positionType() != YGPositionTypeAbsolute) {
+        if (!child->isPositionTypeExcluded()) {
           if (child->getLineIndex() != i) {
             break;
           }
@@ -3585,7 +3587,7 @@ static void YGNodelayoutImpl(
           if (child->getStyle().display() == YGDisplayNone) {
             continue;
           }
-          if (child->getStyle().positionType() != YGPositionTypeAbsolute) {
+          if (!child->isPositionTypeExcluded()) {
             switch (YGNodeAlignItem(node, child)) {
               case YGAlignFlexStart: {
                 child->setLayoutPosition(
@@ -3776,7 +3778,7 @@ static void YGNodelayoutImpl(
   if (performLayout && node->getStyle().flexWrap() == YGWrapWrapReverse) {
     for (uint32_t i = 0; i < childCount; i++) {
       const YGNodeRef child = YGNodeGetChild(node, i);
-      if (child->getStyle().positionType() != YGPositionTypeAbsolute) {
+      if (!child->isPositionTypeExcluded()) {
         child->setLayoutPosition(
             node->getLayout().measuredDimensions[dim[crossAxis]] -
                 child->getLayout().position[pos[crossAxis]] -
@@ -3790,7 +3792,7 @@ static void YGNodelayoutImpl(
     // STEP 10: SIZING AND POSITIONING ABSOLUTE CHILDREN
     for (auto child : node->getChildren()) {
       if (child->getStyle().display() == YGDisplayNone ||
-          child->getStyle().positionType() != YGPositionTypeAbsolute) {
+          !child->isPositionTypeExcluded()) {
         continue;
       }
       YGNodeAbsoluteLayoutChild(
@@ -4281,7 +4283,7 @@ static void YGNodeBlockImpl(
         if (child->getStyle().display() == YGDisplayNone) {
           continue;
         }
-        if (child->getStyle().positionType() == YGPositionTypeAbsolute) {
+        if (child->isPositionTypeExcluded()) {
           // If the child is absolutely positioned and has a
           // top/left/bottom/right set, override all the previously computed
           // positions to set it correctly.
@@ -4460,7 +4462,7 @@ static void YGNodeBlockImpl(
         if (child->getStyle().display() == YGDisplayNone) {
           continue;
         }
-        if (child->getStyle().positionType() != YGPositionTypeAbsolute) {
+        if (!child->isPositionTypeExcluded()) {
           if (child->getLineIndex() != i) {
             break;
           }
@@ -4533,7 +4535,7 @@ static void YGNodeBlockImpl(
           if (child->getStyle().display() == YGDisplayNone) {
             continue;
           }
-          if (child->getStyle().positionType() != YGPositionTypeAbsolute) {
+          if (!child->isPositionTypeExcluded()) {
             
             float childHeight = child->getLayout().dimensions[dim[crossAxis]];
             
@@ -4739,7 +4741,7 @@ static void YGNodeBlockImpl(
   if (performLayout && node->getStyle().flexWrap() == YGWrapWrapReverse) {
     for (uint32_t i = 0; i < childCount; i++) {
       const YGNodeRef child = YGNodeGetChild(node, i);
-      if (child->getStyle().positionType() != YGPositionTypeAbsolute) {
+      if (!child->isPositionTypeExcluded()) {
         child->setLayoutPosition(
             node->getLayout().measuredDimensions[dim[crossAxis]] -
                 child->getLayout().position[pos[crossAxis]] -
@@ -4753,7 +4755,7 @@ static void YGNodeBlockImpl(
     // STEP 10: SIZING AND POSITIONING ABSOLUTE CHILDREN
     for (auto child : node->getChildren()) {
       if (child->getStyle().display() == YGDisplayNone ||
-          child->getStyle().positionType() != YGPositionTypeAbsolute) {
+          !child->isPositionTypeExcluded()) {
         continue;
       }
       YGNodeAbsoluteLayoutChild(

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -2209,7 +2209,7 @@ static YGCollectFlexItemsRowValues YGCalculateCollectBlockItemsRowValues(
         break;
       
       // Otherwise, ensure this child takes up the whole line, then break
-      flexAlgoRowMeasurement.sizeConsumedOnCurrentLine = flexBasisWithMinAndMaxConstraints;
+      flexAlgoRowMeasurement.sizeConsumedOnCurrentLine = flexBasisWithMinAndMaxConstraints + childMarginMainAxis;
       flexAlgoRowMeasurement.isBlockNonInline = true;
       flexAlgoRowMeasurement.itemsOnLine = 1;
       flexAlgoRowMeasurement.totalFlexGrowFactors += child->resolveFlexGrow();

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -4398,7 +4398,7 @@ static void YGNodeBlockImpl(
             continue;
           }
           if (child->getStyle().positionType() != YGPositionTypeAbsolute) {
-            switch (YGNodeAlignItem(node, child)) {
+            switch (YGAlignCenter) { // TODO: use a new verticalAlign property to position items here
               case YGAlignFlexStart: {
                 child->setLayoutPosition(
                     currentLead +

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -1692,7 +1692,8 @@ static void YGNodeAbsoluteLayoutChild(
   
   YGNodeRef ancestor = node, nextAncestor;
   
-  while (ancestor->getStyle().positionType() == YGPositionTypeStatic)
+  while ((ancestor->getStyle().positionType() == YGPositionTypeStatic && child->getStyle().positionType() != YGPositionTypeFixed) ||
+         child->getStyle().positionType() == YGPositionTypeFixed)
   {
     nextAncestor = ancestor->getParent();
     
@@ -1721,7 +1722,8 @@ static void YGNodeOffsetAbsoluteChild(
   float leftOffset = 0;
   float topOffset = 0;
   
-  while (ancestor->getStyle().positionType() == YGPositionTypeStatic)
+  while ((ancestor->getStyle().positionType() == YGPositionTypeStatic && child->getStyle().positionType() != YGPositionTypeFixed) ||
+         child->getStyle().positionType() == YGPositionTypeFixed)
   {
     leftOffset += ancestor->getLayout().position[YGEdgeLeft];
     topOffset += ancestor->getLayout().position[YGEdgeTop];

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -5056,7 +5056,7 @@ bool YGLayoutNodeInternal(
     
     // If the node is set to block formatting, and it is not a leaf node
     // with a measure function, go to the block implementation
-    if (node->isDisplayBlock() && !node->hasMeasureFunc())
+    if (node->getConfig()->enableBlockFormatting && node->isDisplayBlock() && !node->hasMeasureFunc())
       YGNodeBlockImpl(
         node,
         availableWidth,
@@ -5490,20 +5490,30 @@ inline bool YGConfigIsExperimentalFeatureEnabled(
   return config->experimentalFeatures[feature];
 }
 
-YOGA_EXPORT void YGConfigSetUseWebDefaults(
-    const YGConfigRef config,
-    const bool enabled) {
-  config->useWebDefaults = enabled;
-}
-
 YOGA_EXPORT void YGConfigSetUseLegacyStretchBehaviour(
     const YGConfigRef config,
     const bool useLegacyStretchBehaviour) {
   config->useLegacyStretchBehaviour = useLegacyStretchBehaviour;
 }
 
+YOGA_EXPORT void YGConfigSetUseWebDefaults(
+    const YGConfigRef config,
+    const bool enabled) {
+  config->useWebDefaults = enabled;
+}
+
 bool YGConfigGetUseWebDefaults(const YGConfigRef config) {
   return config->useWebDefaults;
+}
+
+YOGA_EXPORT void YGConfigSetEnableBlockFormatting(
+    const YGConfigRef config,
+    const bool enabled) {
+  config->enableBlockFormatting = enabled;
+}
+
+bool YGConfigGetEnableBlockFormatting(const YGConfigRef config) {
+  return config->enableBlockFormatting;
 }
 
 YOGA_EXPORT void YGConfigSetContext(const YGConfigRef config, void* context) {

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -4147,11 +4147,6 @@ static void YGNodeBlockImpl(
           paddingAndBorderAxisCross;
     }
 
-    // If there's no flex wrap, the cross dimension is defined by the container.
-    if (!isNodeFlexWrap && measureModeCrossDim == YGMeasureModeExactly) {
-      collectedFlexItemsValues.crossDim = availableInnerCrossDim;
-    }
-
     // Clamp to the min/max size specified on the container.
     collectedFlexItemsValues.crossDim =
         YGNodeBoundAxis(

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -655,6 +655,20 @@ YOGA_EXPORT YGDisplay YGNodeStyleGetDisplay(const YGNodeConstRef node) {
 }
 
 // TODO(T26792433): Change the API to accept YGFloatOptional.
+YOGA_EXPORT void YGNodeStyleSetDisplayInline(
+    const YGNodeRef node,
+    const float displayInline) {
+  updateStyle<MSVC_HINT(displayInline)>(
+      node, &YGStyle::displayInline, YGFloatOptional{displayInline});
+}
+
+YOGA_EXPORT float YGNodeStyleGetDisplayInline(const YGNodeConstRef node) {
+  return node->getStyle().displayInline().isUndefined()
+      ? YGUndefined
+      : node->getStyle().displayInline().unwrap();
+}
+
+// TODO(T26792433): Change the API to accept YGFloatOptional.
 YOGA_EXPORT void YGNodeStyleSetFlex(const YGNodeRef node, const float flex) {
   updateStyle<MSVC_HINT(flex)>(node, &YGStyle::flex, YGFloatOptional{flex});
 }

--- a/yoga/Yoga.cpp
+++ b/yoga/Yoga.cpp
@@ -2224,17 +2224,17 @@ static float YGDistributeFreeSpaceSecondPass(
                          .unwrap();
     float updatedMainSize = childFlexBasis;
 
+    // If this is taken up by a non-inline block element, use block-formatting rules instead of flex
     if (collectedFlexItemsValues.isBlockNonInline)
     {
+      // Initialise child size as its preferred width
       float childSize = childFlexBasis;
       
-      if (collectedFlexItemsValues.sizeConsumedOnCurrentLine > 0)
-        printf("here\n");
-      
-      if (!node->isDisplayInline() && measureModeMainDim == YGMeasureModeExactly)
+      // If the row dimension is being measured exactly (not "at most") then the block element fills the line
+      if (measureModeMainDim == YGMeasureModeExactly)
         childSize += collectedFlexItemsValues.remainingFreeSpace;
       
-      // Just set size within min max constraints?
+      // Set child size while respecting constraints
       updatedMainSize = YGNodeBoundAxis(
           currentRelativeChild,
           mainAxis,

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -162,6 +162,11 @@ WIN_EXPORT void YGNodeStyleSetJustifyContent(
     YGJustify justifyContent);
 WIN_EXPORT YGJustify YGNodeStyleGetJustifyContent(YGNodeConstRef node);
 
+WIN_EXPORT void YGNodeStyleSetTextAlign(
+    YGNodeRef node,
+    YGAlignText textAlign);
+WIN_EXPORT YGAlignText YGNodeStyleGetTextAlign(YGNodeConstRef node);
+
 WIN_EXPORT void YGNodeStyleSetAlignContent(
     YGNodeRef node,
     YGAlign alignContent);

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -187,6 +187,9 @@ WIN_EXPORT YGOverflow YGNodeStyleGetOverflow(YGNodeConstRef node);
 WIN_EXPORT void YGNodeStyleSetDisplay(YGNodeRef node, YGDisplay display);
 WIN_EXPORT YGDisplay YGNodeStyleGetDisplay(YGNodeConstRef node);
 
+WIN_EXPORT void YGNodeStyleSetDisplayInline(YGNodeRef node, float displayInline);
+WIN_EXPORT float YGNodeStyleGetDisplayInline(YGNodeConstRef node);
+
 WIN_EXPORT void YGNodeStyleSetFlex(YGNodeRef node, float flex);
 WIN_EXPORT float YGNodeStyleGetFlex(YGNodeConstRef node);
 

--- a/yoga/Yoga.h
+++ b/yoga/Yoga.h
@@ -349,6 +349,9 @@ WIN_EXPORT bool YGConfigIsExperimentalFeatureEnabled(
 WIN_EXPORT void YGConfigSetUseWebDefaults(YGConfigRef config, bool enabled);
 WIN_EXPORT bool YGConfigGetUseWebDefaults(YGConfigRef config);
 
+WIN_EXPORT void YGConfigSetEnableBlockFormatting(YGConfigRef config, bool enabled);
+WIN_EXPORT bool YGConfigGetEnableBlockFormatting(YGConfigRef config);
+
 WIN_EXPORT void YGConfigSetCloneNodeFunc(
     YGConfigRef config,
     YGCloneNodeFunc callback);


### PR DESCRIPTION
Implemented block formatting, so we now support `display: block;` `inline-block;` and `inline-flex;`

This is done using a new version of the recursive layout algorithm `YGNodeBlockImpl()` which is heavily modified from the original `YGNodelayoutImpl()`. A wrapper function `YGLayoutNodeInternal()` determines whether a cached layout can be used, and if not it chooses one of these algorithms for the current node. Block formatting is disabled by default, and must be enabled using a YGConfig object, like so:
`YGConfigSetEnableBlockFormatting (yogaConfig.get(), true);` 

Other changes include support for fixed positioning and bugfixes to absolute positioning.

TODO:
Fix relative positioning (it's like "normal" static positioning, but an offset is applied at the end)
Implement vertical-align property for block formatting